### PR TITLE
Fix: bracket-absolute description

### DIFF
--- a/globbing/bracket-absolute/DESCRIPTION.md
+++ b/globbing/bracket-absolute/DESCRIPTION.md
@@ -14,4 +14,4 @@ Look: file_a file_b
 ```
 
 Try it here!
-Change your working directory to `/challenge/files` and, with a single argument, run `/challenge/run` with a single argument that that bracket-globs into `file_b`, `file_a`, `file_s`, and `file_h`!
+With a single argument, run `/challenge/run` with a single argument that that bracket-globs into `file_b`, `file_a`, `file_s`, and `file_h`!


### PR DESCRIPTION
The description of bracket-absolute says:
> Change your working directory to /challenge/files
but it checks whether we run with a working directory of $HOME, so i delete that sentence in the description