### PR TITLE
Fix: order of path and expression in 'find' command

### DIFF
--- a/commands/find/DESCRIPTION.md
+++ b/commands/find/DESCRIPTION.md
@@ -44,7 +44,7 @@ hacker@dojo:~$
 You can search the whole filesystem if you want!
 
 ```console
-hacker@dojo:~$ find -name hacker /
+hacker@dojo:~$ find / -name hacker
 /home/hacker
 hacker@dojo:~$
 ```


### PR DESCRIPTION
According to the man page, the syntax for 'find' is `find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]`, `find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]`.

Therefore, we should do `find / -name hacker` instead of `find -name hacker /`.

In fact, when using the latter, we get the following errors:
> find: paths must precede expression: `/'

> find: possible unquoted pattern after predicate `-name'?