### PR TITLE
[Fix] Update description for chmod

### DIFF
--- a/path/path/DESCRIPTION.md
+++ b/path/path/DESCRIPTION.md
@@ -1,6 +1,6 @@
 It turns out that the answer to "How does the shell find `ls`?" is fairly simple.
 There is a special shell variable, called `PATH`, that stores a bunch of directory paths in which the shell will search for programs corresponding to commands.
-If you blank you the variable, things go badly:
+If you blank out the variable, things go badly:
 
 ```console
 hacker@dojo:~$ ls

--- a/permissions/chmod/DESCRIPTION.md
+++ b/permissions/chmod/DESCRIPTION.md
@@ -3,5 +3,5 @@ Let's practice!
 
 This challenge will ask you to change the permissions of the `/challenge/pwn` file in specific ways a few times in a row.
 If you get the permissions wrong, the game will reset and you can try again.
-If you get the permissions right five times in a row, the challenge will let you `chmod` `/flag` to make it readable for yourself :-)
+If you get the permissions right eight times in a row, the challenge will let you `chmod` `/flag` to make it readable for yourself :-)
 Launch `/challenge/run` to get started!


### PR DESCRIPTION
Fixes an issue where the description of the pwn states that we have to `chmod` `/challenge/pwn` correctly five times but the actual required amount is eight.

### Screenshot of description on `pwn.college`
<img width="925" alt="Screenshot 2024-07-04 at 10 22 45 PM" src="https://github.com/pwncollege/linux-luminarium/assets/120318851/6700b0a0-686c-40f4-9793-7f86bb468a27">

### Screenshot of actual challenge
<img width="279" alt="Screenshot 2024-07-04 at 10 22 28 PM" src="https://github.com/pwncollege/linux-luminarium/assets/120318851/f1f90a68-8fff-48ce-a547-feee554fb0e9">