### PR TITLE
Piping Procsub Tee Description

### DIFF
--- a/piping/procsub-write/DESCRIPTION.md
+++ b/piping/procsub-write/DESCRIPTION.md
@@ -12,10 +12,8 @@ hacker@dojo:~$
 And you've used `tee` to duplicate data to a file and a command:
 
 ```console
-hacker@dojo:~$ echo HACK | tee THE > PLANET
+hacker@dojo:~$ echo HACK | tee THE | cat
 hacker@dojo:~$ cat THE
-HACK
-hacker@dojo:~$ cat PLANET
 HACK
 hacker@dojo:~$
 ```


### PR DESCRIPTION
Description showing using `tee` to write to a file and pass input to a process is incorrect.  Changes description to pipe stdout to `cat` as example of `tee` stdout piping.