### PR TITLE
Checking if .state's owner is root.

### DIFF
--- a/permissions/chmod/run
+++ b/permissions/chmod/run
@@ -47,7 +47,13 @@ def print_status():
 	explain_permissions("Needed", NEEDED_PERMS)
 
 def check():
-	if os.stat(TARGET).st_mode & 0o777 == NEEDED_PERMS:
+	if os.path.exists(STATE_PATH) and os.stat(STATE_PATH).st_uid != 0:
+		print("Nice try. Restarting the game!")
+		os.chmod(TARGET, 0o644)
+		if os.path.exists(STATE_PATH):
+			os.unlink(STATE_PATH)
+		return False  
+	elif os.stat(TARGET).st_mode & 0o777 == NEEDED_PERMS:
 		print("You set the correct permissions!")
 		with open(STATE_PATH, "wb") as o:
 			pickle.dump((ROUND+1, next_perms(r=ROUND)), o)


### PR DESCRIPTION
The challenge "Permission Tweaking Practice" uses a pickle object and it keeps saved in `/tmp/.state`.

		with open(STATE_PATH, "wb") as o:
			pickle.dump((ROUND+1, next_perms(r=ROUND)), o)

Doing the challenge normally, the permissions in this file is only for `root` to write and for hacker to `read`. It also keeps track of the current round and the next permissions to be checked. If a user creates this file (`/tmp/.state`)  before running the challenge for the first time, `hacker` will be the owner of the file and it may be possible to bypass all the rounds just writing anything to be checked.

To avoid this, I included something like:
	if os.path.exists(STATE_PATH) and os.stat(STATE_PATH).st_uid != 0:

That will guarantee the ownership of this file. Also I don't know the best message warn the user about this, then I just wrote: `"Nice try. Restarting the game!"`.