### PR TITLE
Fix typos and grammar in docs

### DIFF
--- a/builtins/DESCRIPTION.md
+++ b/builtins/DESCRIPTION.md
@@ -9,4 +9,4 @@ Some questions that we will explore:
 - How to implement complex functionality right in your shell!
 
 We will learn how to use the functionality built into the shell itself (e.g., builtins and other functionality).
-No, go forth and learn!
+Now, go forth and learn!

--- a/chaining/DESCRIPTION.md
+++ b/chaining/DESCRIPTION.md
@@ -1,5 +1,5 @@
 In the piping module, you've explored the concept of using several commands, with data flowing between them via pipes, to accomplish something slightly more complex than the individual commands can do.
-Of course, this concept also applies independent of the data transfer: sometimes, you might want to run several commands in quick succession to achieve up some cumulative effect.
+Of course, this concept also applies independent of the data transfer: sometimes, you might want to run several commands in quick succession to achieve some cumulative effect.
 
 This module will cover a few ways, aside from piping, that commands can be chained.
 By the end, you'll be on your way to writing _shell scripts_!

--- a/chaining/semicolon/DESCRIPTION.md
+++ b/chaining/semicolon/DESCRIPTION.md
@@ -17,7 +17,7 @@ COLLEGE
 hacker@dojo:~$
 ```
 
-Basically, when you hit Enter, your shell executes your typed command and, after that command terminates, give you the prompt to input another command.
+Basically, when you hit Enter, your shell executes your typed command and, after that command terminates, gives you the prompt to input another command.
 The semicolon is analogous, just without the prompt and with you entering both commands before anything is executed.
 
 Give it a try now! In this level, you must run `/challenge/pwn` and then `/challenge/college`, chaining them with a semicolon.

--- a/commands/grep/DESCRIPTION.md
+++ b/commands/grep/DESCRIPTION.md
@@ -2,7 +2,7 @@ Sometimes, the files that you might `cat` out are too big.
 Luckily, we have the `grep` command to search for the contents we need!
 We'll learn it in this challenge.
 
-There are many ways to `grep`, and we'll learn on way here:
+There are many ways to `grep`, and we'll learn one way here:
 
 ```console
 hacker@dojo:~$ grep SEARCH_STRING /path/to/file

--- a/commands/ln-s/DESCRIPTION.md
+++ b/commands/ln-s/DESCRIPTION.md
@@ -1,5 +1,5 @@
 If you use Linux (or computers) for any reasonable length of time to do any real work, you will eventually run into some variant of the following situation: you want two programs to access the same data, but the programs expect that data to be in two different locations.
-Luckily, Linux provides a solution to this quandry: _links_.
+Luckily, Linux provides a solution to this quandary: _links_.
 
 Links come in two flavors: _hard_ and _soft_ (also known as _symbolic_) links.
 We'll differentiate the two with an analogy:
@@ -8,14 +8,14 @@ We'll differentiate the two with an analogy:
 - A **soft** link is when you move apartments and have the postal service automatically forward your mail from your old place to your new place.
 
 In a filesystem, a file is, conceptually, an address at which the contents of that file live.
-A hard link is an alternate address that indexes that data --- accesses to the hard link and accesses to the original file are completely identical, in that they immediate yield the necessary data.
+A hard link is an alternate address that indexes that data --- accesses to the hard link and accesses to the original file are completely identical, in that they immediately yield the necessary data.
 A soft/symbolic link, instead, contains the original file name.
 When you access the symbolic link, Linux will realize that it is a symbolic link, read the original file name, and then (typically) automatically access that file.
 In most cases, both situations result in accessing the original data, but the mechanisms are different.
 
 Hard links sound simpler to most people (case in point, I explained it in one sentence above, versus two for soft links), but they have various downsides and implementation gotchas that make soft/symbolic links, by far, the more popular alternative.
 
-In this challenge, we will learn about symbolic links (also also known as _symlinks_).
+In this challenge, we will learn about symbolic links (also known as _symlinks_).
 Symbolic links are created with the `ln` command with the `-s` argument, like so:
 
 ```console

--- a/globbing/bracket/DESCRIPTION.md
+++ b/globbing/bracket/DESCRIPTION.md
@@ -1,5 +1,5 @@
 Next, we will cover `[]`.
-The square brackes are, essentially, a limited form of `?`, in that instead of matching any character, `[]` is a wildcard for some subset of potential characters, specified within the brackets.
+The square brackets are, essentially, a limited form of `?`, in that instead of matching any character, `[]` is a wildcard for some subset of potential characters, specified within the brackets.
 For example, `[pwn]` will match the character `p`, `w`, or `n`.
 For example:
 

--- a/globbing/question/DESCRIPTION.md
+++ b/globbing/question/DESCRIPTION.md
@@ -1,5 +1,5 @@
 Next, let's learn about `?`.
-When it encounters a `?` character in any argument, the shell will treat it as **single-character** wildcard.
+When it encounters a `?` character in any argument, the shell will treat it as a **single-character** wildcard.
 This works like `*`, but only matches _one_ character.
 For example:
 

--- a/path/path-win/DESCRIPTION.md
+++ b/path/path-win/DESCRIPTION.md
@@ -11,7 +11,7 @@ hacker@dojo:~$ goodscript
 bash: goodscript: command not found
 hacker@dojo:~$ /home/hacker/scripts/goodscript
 YEAH! This is the best script!
-hacker@dojo:~l
+hacker@dojo:~$
 ```
 
 If you maintain useful scripts that you want to be able to launch by bare name, this is annoying.

--- a/paths/relative-dot-local/DESCRIPTION.md
+++ b/paths/relative-dot-local/DESCRIPTION.md
@@ -1,4 +1,4 @@
-In this level, we'll practice refering to paths using `.` a bit more.
+In this level, we'll practice referring to paths using `.` a bit more.
 This challenge will need you to run it from the `/challenge` directory.
 Here, things get slightly tricky.
 
@@ -18,6 +18,6 @@ As a result, the above commands will yield the following error:
 bash: run: command not found
 ```
 
-We'll explore the mechanisms behind this concept later, but in this challenge, will learn how to explicitly use relative paths to launch `run` in this scenario.
+We'll explore the mechanisms behind this concept later, but in this challenge, we'll learn how to explicitly use relative paths to launch `run` in this scenario.
 The way to do this is to *tell* Linux that you explicitly want to execute a program in the current directory, using `.` like in the previous levels.
 Give it a try now!

--- a/permissions/DESCRIPTION.md
+++ b/permissions/DESCRIPTION.md
@@ -1,4 +1,4 @@
-This module will expose you to Linux permissions, which is one of the most important part of your journey going ahead. 
+This module will expose you to Linux permissions, which is one of the most important parts of your journey going ahead.
 
 In Linux, files have different permissions or file modes. You can check out a permissions of a file or directory using `ls -l`.
 Let's make some files and look at their permissions:

--- a/permissions/chgrp/DESCRIPTION.md
+++ b/permissions/chgrp/DESCRIPTION.md
@@ -41,7 +41,7 @@ zardus@yourcomputer:~$
 ```
 
 This file is a special _device file_ (type `c` means it is a "character device"), and interacting with it results in changes to the display output (rather than changes to disk storage, as for a normal file!).
-Zardus' user account on his machine can interact with it because the the file has a group ownership of `video`, and Zardus is a member of the `video` group.
+Zardus' user account on his machine can interact with it because the file has a group ownership of `video`, and Zardus is a member of the `video` group.
 
 No such luck for the `/flag` file in the dojo, though!
 Consider the following:

--- a/permissions/execute/DESCRIPTION.md
+++ b/permissions/execute/DESCRIPTION.md
@@ -14,7 +14,7 @@ hacker@dojo:~$
 ```
 
 In this case, `/challenge/run` runs because it is executable by the `hacker` user.
-Because the file is owned by the `root` user and `root` group, this requires that the execute bit is set on the `other` permissions).
+Because the file is owned by the `root` user and `root` group, this requires that the execute bit is set on the `other` permissions.
 If we remove these permissions, the execution will fail!
 
 ```console

--- a/permissions/setuid/DESCRIPTION.md
+++ b/permissions/setuid/DESCRIPTION.md
@@ -3,7 +3,7 @@ The system admin can't be there to give them the password every time a user want
 The "Set User ID" (SUID) permissions bit allows the user to run a program as the owner of that program's file.
 
 This is actually the exact mechanism used to let the challenge programs you run read the flag or, outside of pwn.college, to enable system administration tools such as `su`, `sudo`, and so on.
-The permission of a file with SUID list look like this:
+The permissions of a file with SUID look like this:
 
 ```console
 hacker@dojo:~$ ls -l /usr/bin/sudo

--- a/piping/echo/DESCRIPTION.md
+++ b/piping/echo/DESCRIPTION.md
@@ -1,4 +1,4 @@
-First, let's look at redirect stdout to files.
+First, let's look at redirecting stdout to files.
 You can accomplish this with the `>` character, as so:
 
 ```console

--- a/piping/procsub-write/DESCRIPTION.md
+++ b/piping/procsub-write/DESCRIPTION.md
@@ -30,7 +30,7 @@ NAME
 ```
 
 Luckily, Linux follows the philosophy that ["everything is a file"](https://en.wikipedia.org/wiki/Everything_is_a_file).
-This is, the system strives to provide file-like access to most resources, including the input and output of running programs!
+That is, the system strives to provide file-like access to most resources, including the input and output of running programs!
 The shell follows this philosophy, allowing you to, for example, use any utility that takes file arguments on the command line (such as `tee`) and hook it up to the input or output side of a program!
 
 This is done using what's called [Process Substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html).
@@ -71,7 +71,7 @@ Run the `/challenge/hack` command, and duplicate its output as input to both the
 ----
 **Trivia!**
 
-The observant learner will realize that the following are equivalant:
+The observant learner will realize that the following are equivalent:
 
 ```console
 hacker@dojo:~$ echo hi | rev

--- a/piping/tr-delete/DESCRIPTION.md
+++ b/piping/tr-delete/DESCRIPTION.md
@@ -1,5 +1,5 @@
 `tr` can also translate characters to nothing (i.e., _delete_ them).
-This is done via a `-d` flag and an argument of what characters to delte:
+This is done via a `-d` flag and an argument of what characters to delete:
 
 ```console
 hacker@dojo:~$ echo PAWN | tr -d 'A'

--- a/processes/ps/DESCRIPTION.md
+++ b/processes/ps/DESCRIPTION.md
@@ -70,7 +70,7 @@ Plus, there's a bunch of other stuff we won't get into right now.
 Anyways!
 Let's practice.
 In this level, I have once again renamed `/challenge/run` to a random filename, and this time made it so that you cannot `ls` the `/challenge` directory!
-But I also launched it, so can find it in the running process list, figure out the filename, and relaunch it directly for the flag!
+But I also launched it, so you can find it in the running process list, figure out the filename, and relaunch it directly for the flag!
 Good luck!
 
 **NOTE:** Both `ps -ef` and `ps aux` truncate the command listing to the width of your terminal (which is why the examples above line up so nicely on the right side of the screen.

--- a/processes/start-backgrounded/DESCRIPTION.md
+++ b/processes/start-backgrounded/DESCRIPTION.md
@@ -1,4 +1,4 @@
-Of course, you don't have to suspend processes to background them: you can start the backgrounded right off the bat!
+Of course, you don't have to suspend processes to background them: you can start them backgrounded right off the bat!
 It's easy; all you have to do is append a `&` to the command, like so:
 
 ```console

--- a/variables/command-substitution/DESCRIPTION.md
+++ b/variables/command-substitution/DESCRIPTION.md
@@ -15,7 +15,7 @@ Read the output of the `/challenge/run` command directly into a variable called 
 
 ----
 **Trivia:**
-You can also backticks instead of `$()`: `` FLAG=`cat /flag` `` instead of ``FLAG=$(cat /flag)`` in the example above.
+You can also use backticks instead of `$()`: `` FLAG=`cat /flag` `` instead of ``FLAG=$(cat /flag)`` in the example above.
 This is an older format, and has some disadvantages (for example, imagine if you wanted to _nest_ command substitutions.
 How would you do `$(cat $(find / -name flag))` with backticks?
 The official stance of pwn.college is that you should use `$(blah)` instead of `` `blah` ``.


### PR DESCRIPTION
## Summary
- fix typos across documentation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68404b919a9483338d8a51e689297c39