### PR TITLE
fixing typo in flag_getter

### DIFF
--- a/shenanigans/config-snooping/bin/flag_getter
+++ b/shenanigans/config-snooping/bin/flag_getter
@@ -4,7 +4,7 @@ read API_KEY < /challenge/.victim_pass
 
 if [ "$1" == "$API_KEY" ] || [ "$2" == "$API_KEY" ]
 then
-	echo "Correct API key! Do you want me to print the key (y/n)?"
+	echo "Correct API key! Do you want me to print the flag (y/n)?"
 	read
 	[ "$REPLY" == "y" ] && cat /flag
 	echo


### PR DESCRIPTION
There is a typo in `flag_getter ` as it asks to print the `key` instead of the `flag`