### PR TITLE
Wrong URL on shell variable link leads to page not found DESCRIPTION.md

### DIFF
--- a/path/path/DESCRIPTION.md
+++ b/path/path/DESCRIPTION.md
@@ -19,5 +19,5 @@ This program will **DELETE** the flag file using the `rm` command.
 However, if it can't find the `rm` command, the flag will not be deleted, and the challenge will give it to you!
 Thus, you must make it so that `/challenge/run` also can't find the `rm` command!
 
-Keep in mind: `/challenge/run` will be a _child process_ of your shell, so you must apply the concepts you learned in [Shell Variables](../variables) to mess with its `PATH` variable!
+Keep in mind: `/challenge/run` will be a _child process_ of your shell, so you must apply the concepts you learned in [Shell Variables](https://pwn.college/linux-luminarium/variables/) to mess with its `PATH` variable!
 If you don't succeed, and the flag gets deleted, you will need to restart the challenge to try again!


### PR DESCRIPTION
Goes to https://pwn.college/variables(404) instead of https://pwn.college/variables