### PR TITLE
LL-chaining-Scripts-ELIF description add

### DIFF
--- a/chaining/script-elif/DESCRIPTION.md
+++ b/chaining/script-elif/DESCRIPTION.md
@@ -27,6 +27,7 @@ For this challenge, write a script at `/home/hacker/solve.sh` that:
 - If the argument is "pwn", output "college"  
 - If the argument is "learn", output "linux"
 - For any other input, output "unknown"
+Critical note: As you're creating your script, make sure to follow the spacing closely in the examples. A a bracket `[` too close to a quotation mark `"` may result in a script failure. Keep at it even if it fails the first time, scripts don't always work on the first try. You should test your script for errors manually.
 
 Example:
 

--- a/chaining/script-elif/DESCRIPTION.md
+++ b/chaining/script-elif/DESCRIPTION.md
@@ -27,7 +27,6 @@ For this challenge, write a script at `/home/hacker/solve.sh` that:
 - If the argument is "pwn", output "college"  
 - If the argument is "learn", output "linux"
 - For any other input, output "unknown"
-Critical note: As you're creating your script, make sure to follow the spacing closely in the examples. A a bracket `[` too close to a quotation mark `"` may result in a script failure. Keep at it even if it fails the first time, scripts don't always work on the first try. You should test your script for errors manually.
 
 Example:
 
@@ -44,3 +43,8 @@ hacker@dojo:~$
 ```
 
 Once your script works correctly, run `/challenge/run` to get your flag!
+
+----
+**NOTE:**
+As you're creating your script, make sure to follow the spacing closely in the examples.
+Unlike many other languages, bash requires the `[` and the `]` to be separated from other characters by spaces, otherwise it cannot parse the condition.


### PR DESCRIPTION
Added a critical note in the description next to the challenge information about white space for bash scripts. I knew python cared, I didn't know bash cared about how close a `[` and a `"` were.  This change may help increase the solve rate