### PR TITLE
Consistent spelling of "Ctrl-C"

### DIFF
--- a/processes/int/DESCRIPTION.md
+++ b/processes/int/DESCRIPTION.md
@@ -6,4 +6,4 @@ Try it here!
 Good luck!
 
 ---
-For the very interested, check out this [article about terminals and "control codes"](https://catern.com/posts/terminal_quirks.html) (such as `Ctrl^C`).
+For the very interested, check out this [article about terminals and "control codes"](https://catern.com/posts/terminal_quirks.html) (such as `Ctrl-C`).


### PR DESCRIPTION
We should use either "Ctrl-C" (like we did above) or "Ctrl^C" for both of them.

We are also using this "Ctrl-?" spelling in other challenges, so I think we should keep that one and change the "Ctrl^?" spelling.