### PR TITLE
Remove enter from description as run is fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/terminal-multiplexing/detach-attach/DESCRIPTION.md
+++ b/terminal-multiplexing/detach-attach/DESCRIPTION.md
@@ -24,7 +24,7 @@ hacker@dojo:~$ screen -r
 
 For this challenge, you'll need to:
 
-1. Launch screen and press enter
+1. Launch screen
 2. Detach from it.
 3. Run `/challenge/run` (this will secretly send the flag to your detached session!)
 4. Reattach to see your prize

--- a/terminal-multiplexing/detach-attach/run
+++ b/terminal-multiplexing/detach-attach/run
@@ -7,7 +7,6 @@ if [ -z "$SCREEN_SESSION" ]; then
     echo ""
     echo "You need to:"
     echo "1. Launch screen with: screen"
-    echo "Note: Make sure to press enter after attaching the screen"
     echo "2. Detach from it with: Ctrl-A then d"
     echo "3. Then run this program again"
     exit 1


### PR DESCRIPTION
I forgot to get rid of the `enter` changes from the challenge and description, this removes that