### PR TITLE
Module-wide flag bypass via PATH hijacking

### DIFF
--- a/chaining/reading-scripts/run
+++ b/chaining/reading-scripts/run
@@ -1,10 +1,18 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 read GUESS
 if [ "$GUESS" == "hack the PLANET" ]
 then
 	echo "CORRECT! Your flag:"
-	cat /flag
+	/bin/cat /flag
 else
 	echo "Read the /challenge/run file to figure out the correct password!"
 fi

--- a/chaining/script-args/run
+++ b/chaining/script-args/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 SCRIPT_PATH="/home/hacker/solve.sh"
 
@@ -16,7 +24,7 @@ EXPECTED="$WORD2 $WORD1"
 if [ "$OUTPUT" = "$EXPECTED" ]; then
     echo "Correct! Your script properly reversed the arguments."
     echo "Here's your flag:"
-    cat /flag
+    /bin/cat /flag
 else
     echo "Not quite right!"
     echo "Expected: $EXPECTED"

--- a/chaining/script-elif/run
+++ b/chaining/script-elif/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 SCRIPT_PATH="/home/hacker/solve.sh"
 
@@ -31,4 +39,4 @@ done
 
 echo "Correct! Your script properly handles all the conditions with elif."
 echo "Here's your flag:"
-cat /flag
+/bin/cat /flag

--- a/chaining/script-else/run
+++ b/chaining/script-else/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 SCRIPT_PATH="/home/hacker/solve.sh"
 
@@ -31,4 +39,4 @@ done
 
 echo "Correct! Your script properly handles the if/else conditions."
 echo "Here's your flag:"
-cat /flag
+/bin/cat /flag

--- a/chaining/script-if/run
+++ b/chaining/script-if/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 SCRIPT_PATH="/home/hacker/solve.sh"
 
@@ -29,4 +37,4 @@ done
 
 echo "Correct! Your script properly handles all the conditions."
 echo "Here's your flag:"
-cat /flag
+/bin/cat /flag

--- a/chaining/shebang/run
+++ b/chaining/shebang/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/python
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 import os
 import sys

--- a/commands/cat-absolute/run
+++ b/commands/cat-absolute/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /challenge/DESCRIPTION.md
+/bin/cat /challenge/DESCRIPTION.md

--- a/commands/cat-chase/run
+++ b/commands/cat-chase/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s < /challenge/DESCRIPTION.md
+/usr/bin/fold -s < /challenge/DESCRIPTION.md

--- a/commands/cat/run
+++ b/commands/cat/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /challenge/DESCRIPTION.md
+/bin/cat /challenge/DESCRIPTION.md

--- a/commands/find/run
+++ b/commands/find/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "The flag is hidden (and readable) somewhere on the filesystem. Go find it!"
+/usr/bin/fold -s <<< "The flag is hidden (and readable) somewhere on the filesystem. Go find it!"

--- a/commands/grep/run
+++ b/commands/grep/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /challenge/DESCRIPTION.md
+/bin/cat /challenge/DESCRIPTION.md

--- a/commands/ls-a/run
+++ b/commands/ls-a/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "There's no flag here for you! I made the flag readable but hid it as a .-prepended file in the / directory. Go find it!"

--- a/commands/ls/run
+++ b/commands/ls/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "Yahaha, you found me! Here is your flag:"
-cat /flag
+/bin/cat /flag

--- a/commands/mkdir/run
+++ b/commands/mkdir/run
@@ -1,16 +1,24 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ ! -d /tmp/pwn ]
 then
-	fold -s <<< "Uh oh! /tmp/pwn does not exist as a directory. Please use the 'mkdir' command to create it!"
+	/usr/bin/fold -s <<< "Uh oh! /tmp/pwn does not exist as a directory. Please use the 'mkdir' command to create it!"
 	exit 1
 fi
 
 if [ ! -f /tmp/pwn/college ]
 then
-	fold -s <<< "Uh oh! /tmp/pwn/college does not exist. Please use the 'touch' command to create it!"
+	/usr/bin/fold -s <<< "Uh oh! /tmp/pwn/college does not exist. Please use the 'touch' command to create it!"
 	exit 2
 fi
 
 echo "Success! Here is your flag:"
-cat /flag
+/bin/cat /flag

--- a/commands/touch/run
+++ b/commands/touch/run
@@ -1,16 +1,24 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ ! -f /tmp/pwn ]
 then
-	fold -s <<< "Uh oh! /tmp/pwn does not exist. Please use the 'touch' command to create it!"
+	/usr/bin/fold -s <<< "Uh oh! /tmp/pwn does not exist. Please use the 'touch' command to create it!"
 	exit 1
 fi
 
 if [ ! -f /tmp/college ]
 then
-	fold -s <<< "Uh oh! /tmp/college does not exist. Please use the 'touch' command to create it!"
+	/usr/bin/fold -s <<< "Uh oh! /tmp/college does not exist. Please use the 'touch' command to create it!"
 	exit 2
 fi
 
 echo "Success! Here is your flag:"
-cat /flag
+/bin/cat /flag

--- a/data/cut/run
+++ b/data/cut/run
@@ -1,5 +1,13 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /flag | while IFS= read -n1 C; do
+/bin/cat /flag | while IFS= read -n1 C; do
     [ -n "$C" ] && echo "$RANDOM $C"
 done

--- a/data/tr-delete-newlines/run
+++ b/data/tr-delete-newlines/run
@@ -1,7 +1,15 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "Your line-split flag: "
-cat /flag | while IFS= read -n1 c; do
+/bin/cat /flag | while IFS= read -n1 c; do
   printf '%s' "$c"
   (( RANDOM % 100 < 60 )) && printf '\n'
 done

--- a/data/tr-delete/run
+++ b/data/tr-delete/run
@@ -1,7 +1,15 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "Your character-stuffed flag:"
-cat /flag | while IFS= read -n1 c; do
+/bin/cat /flag | while IFS= read -n1 c; do
   printf '%s' "$c"
   (( RANDOM % 100 < 60 )) && printf '^'
   (( RANDOM % 100 < 60 )) && printf '%%'

--- a/data/tr/run
+++ b/data/tr/run
@@ -1,5 +1,13 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "Your case-swapped flag:"
-cat /flag | tr '[A-Z][a-z]' '[a-z][A-Z]'
+/bin/cat /flag | tr '[A-Z][a-z]' '[a-z][A-Z]'
 echo

--- a/globbing/asterisk/run
+++ b/globbing/asterisk/run
@@ -1,12 +1,20 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ "$PWD" != "/challenge" ]
 then
-	fold -s <<< "You must run me /challenge as the working directory. Try to change your working directory to /challenge, then re-run me."
+	/usr/bin/fold -s <<< "You must run me /challenge as the working directory. Try to change your working directory to /challenge, then re-run me."
 elif [ ! -f /tmp/.good_cd ]
 then
-	fold -s <<< "You've somehow made your working directory /challenge without using 'cd' and globbing. Please try again."
+	/usr/bin/fold -s <<< "You've somehow made your working directory /challenge without using 'cd' and globbing. Please try again."
 else
-	fold -s <<< "You ran me with the working directory of /challenge! Here is your flag:"
-	cat /flag
+	/usr/bin/fold -s <<< "You ran me with the working directory of /challenge! Here is your flag:"
+	/bin/cat /flag
 fi

--- a/globbing/bracket-absolute/run
+++ b/globbing/bracket-absolute/run
@@ -1,35 +1,43 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 read -a ARGS < /tmp/.last_arg
 
 if [ "$PWD" != "$HOME" ]
 then
-	fold -s <<< "Error: please run with a working directory of $HOME!"
+	/usr/bin/fold -s <<< "Error: please run with a working directory of $HOME!"
 	exit 1
 fi
 
 if [ "${#ARGS[@]}" -eq 0 ]
 then
-	fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
 	exit 2
 fi
 
 if [ "${#ARGS[@]}" -gt 1 ]
 then
-	fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
 	exit 3
 fi
 
 if [[ "${ARGS[0]}" != *"["* ]]
 then
-	fold -s <<< "Error: you did not use a square bracket glob..."
+	/usr/bin/fold -s <<< "Error: you did not use a square bracket glob..."
 	exit 4
 fi
 
 if [[ "${ARGS[0]}" != *"/challenge/files/"* ]]
 then
-	fold -s <<< "Error: you will need to specify the path to the files as part of your glob argument, since they are in a different directory than your current working directory!"
-	[[ "${ARGS[0]}" == *"/challenge/"* ]] && fold -s <<< "HINT: You are trying to specify files in the $(dirname ${ARGS[0]}) directory, but the files are actually in the /challenge/files directory."
+	/usr/bin/fold -s <<< "Error: you will need to specify the path to the files as part of your glob argument, since they are in a different directory than your current working directory!"
+	[[ "${ARGS[0]}" == *"/challenge/"* ]] && /usr/bin/fold -s <<< "HINT: You are trying to specify files in the $(dirname ${ARGS[0]}) directory, but the files are actually in the /challenge/files directory."
 
 	exit 5
 fi
@@ -37,9 +45,9 @@ fi
 
 if [[ "$1" == *"/file_a" ]] && [[ "$2" == *"/file_b" ]] && [[ "$3" == *"/file_h" ]] && [[ "$4" == *"/file_s" ]]
 then
-	fold -s <<< "You got it! Here is your flag!"
-	cat /flag
+	/usr/bin/fold -s <<< "You got it! Here is your flag!"
+	/bin/cat /flag
 else
-	fold -s <<< "Your expansion did not expand to the requested files (/challenge/files/file_b, /challenge/files/file_a, /challenge/files/file_s, and /challenge/files/file_h). Instead, it expanded to:"
+	/usr/bin/fold -s <<< "Your expansion did not expand to the requested files (/challenge/files/file_b, /challenge/files/file_a, /challenge/files/file_s, and /challenge/files/file_h). Instead, it expanded to:"
 	echo "$@"
 fi

--- a/globbing/bracket/run
+++ b/globbing/bracket/run
@@ -1,36 +1,44 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 read -a ARGS < /tmp/.last_arg
 
 if [ "$PWD" != "/challenge/files" ]
 then
-	fold -s <<< "Error: please run with a working directory of /challenge/files!"
+	/usr/bin/fold -s <<< "Error: please run with a working directory of /challenge/files!"
 	exit 1
 fi
 
 if [ "${#ARGS[@]}" -eq 0 ]
 then
-	fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
 	exit 2
 fi
 
 if [ "${#ARGS[@]}" -gt 1 ]
 then
-	fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
 	exit 3
 fi
 
 if [[ "${ARGS[0]}" != *"["* ]]
 then
-	fold -s <<< "Error: you did not use a square bracket glob..."
+	/usr/bin/fold -s <<< "Error: you did not use a square bracket glob..."
 	exit 4
 fi
 
 if [ "$1" == "file_a" ] && [ "$2" == "file_b" ] && [ "$3" == "file_h" ] && [ "$4" == "file_s" ]
 then
-	fold -s <<< "You got it! Here is your flag!"
-	cat /flag
+	/usr/bin/fold -s <<< "You got it! Here is your flag!"
+	/bin/cat /flag
 else
-	fold -s <<< "Your expansion did not expand to the requested files (file_a, file_b, file_h, and file_s). Instead, it expanded to:"
+	/usr/bin/fold -s <<< "Your expansion did not expand to the requested files (file_a, file_b, file_h, and file_s). Instead, it expanded to:"
 	echo "$@"
 fi

--- a/globbing/mixing/run
+++ b/globbing/mixing/run
@@ -1,42 +1,50 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 read -a ARGS < /tmp/.last_arg
 
 if [ "$PWD" != "/challenge/files" ]
 then
-	fold -s <<< "Error: please run with a working directory of /challenge/files!"
+	/usr/bin/fold -s <<< "Error: please run with a working directory of /challenge/files!"
 	exit 1
 fi
 
 if [ "${#ARGS[@]}" -eq 0 ]
 then
-	fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
 	exit 2
 fi
 
 if [ "${#ARGS[@]}" -gt 1 ]
 then
-	fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
 	exit 3
 fi
 
 if [[ "${ARGS[0]}" != *"["* ]]
 then
-	fold -s <<< "Error: you did not use a square bracket glob..."
+	/usr/bin/fold -s <<< "Error: you did not use a square bracket glob..."
 	exit 4
 fi
 
 if [[ "${#ARGS[0]}" -gt 6 ]]
 then
-	fold -s <<< "Error: your argument is too long! It must be 6 characters or less."
+	/usr/bin/fold -s <<< "Error: your argument is too long! It must be 6 characters or less."
 	exit 4
 fi
 
 if [ "$1" == "challenging" ] && [ "$2" == "educational" ] && [ "$3" == "pwning" ]
 then
-	fold -s <<< "You got it! Here is your flag!"
-	cat /flag
+	/usr/bin/fold -s <<< "You got it! Here is your flag!"
+	/bin/cat /flag
 else
-	fold -s <<< "Your expansion did not expand to the requested files (challenging, educational, pwning). Instead, it expanded to:"
+	/usr/bin/fold -s <<< "Your expansion did not expand to the requested files (challenging, educational, pwning). Instead, it expanded to:"
 	echo "$@"
 fi

--- a/globbing/multiglob/run
+++ b/globbing/multiglob/run
@@ -1,34 +1,42 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 read -a ARGS < /tmp/.last_arg
 
 if [ "$PWD" != "/challenge/files" ]
 then
-	fold -s <<< "Error: please run with a working directory of /challenge/files!"
+	/usr/bin/fold -s <<< "Error: please run with a working directory of /challenge/files!"
 	exit 1
 fi
 
 if [ "${#ARGS[@]}" -eq 0 ]
 then
-	fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
 	exit 2
 fi
 
 if [ "${#ARGS[@]}" -gt 1 ]
 then
-	fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
 	exit 3
 fi
 
 if [[ "${ARGS[0]}" != *"*"* ]]
 then
-	fold -s <<< "Error: you did not use a wildcard glob..."
+	/usr/bin/fold -s <<< "Error: you did not use a wildcard glob..."
 	exit 4
 fi
 
 if [[ "${#ARGS[0]}" -gt 3 ]]
 then
-	fold -s <<< "Error: your argument is too long! It must be 3 characters or less."
+	/usr/bin/fold -s <<< "Error: your argument is too long! It must be 3 characters or less."
 	exit 4
 fi
 
@@ -37,10 +45,10 @@ ASTR=$@
 
 if [ "$EXPECTED" == "$ASTR" ]
 then
-	fold -s <<< "You got it! Here is your flag!"
-	cat /flag
+	/usr/bin/fold -s <<< "You got it! Here is your flag!"
+	/bin/cat /flag
 else
-	fold -s <<< "Your expansion did not expand to the requested files ($EXPECTED)."
-	fold -s <<< "Instead, it expanded to:"
+	/usr/bin/fold -s <<< "Your expansion did not expand to the requested files ($EXPECTED)."
+	/usr/bin/fold -s <<< "Instead, it expanded to:"
 	echo "$ASTR"
 fi

--- a/globbing/question/run
+++ b/globbing/question/run
@@ -1,12 +1,20 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ "$PWD" != "/challenge" ]
 then
-	fold -s <<< "You must run me /challenge as the working directory. Try to change your working directory to /challenge, then re-run me."
+	/usr/bin/fold -s <<< "You must run me /challenge as the working directory. Try to change your working directory to /challenge, then re-run me."
 elif [ ! -f /tmp/.good_cd ]
 then
-	fold -s <<< "You've somehow made your working directory /challenge without using 'cd' and globbing. Please try again."
+	/usr/bin/fold -s <<< "You've somehow made your working directory /challenge without using 'cd' and globbing. Please try again."
 else
-	fold -s <<< "You ran me with the working directory of /challenge! Here is your flag:"
-	cat /flag
+	/usr/bin/fold -s <<< "You ran me with the working directory of /challenge! Here is your flag:"
+	/bin/cat /flag
 fi

--- a/globbing/unmatching/run
+++ b/globbing/unmatching/run
@@ -1,34 +1,42 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 read -a ARGS < /tmp/.last_arg
 
 if [[ "$PWD" != *"/files" ]]
 then
-	fold -s <<< "Error: please run with a working directory of /challenge/files!"
+	/usr/bin/fold -s <<< "Error: please run with a working directory of /challenge/files!"
 	exit 1
 fi
 
 if [ "${#ARGS[@]}" -eq 0 ]
 then
-	fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with no arguments! Please call me with one argument."
 	exit 2
 fi
 
 if [ "${#ARGS[@]}" -gt 1 ]
 then
-	fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
+	/usr/bin/fold -s <<< "Error: you called this command with more than 1 argument (pre-globbing)! Please call me with one argument."
 	exit 3
 fi
 
 if [[ "${ARGS[0]}" != *"["* ]]
 then
-	fold -s <<< "Error: you did not use a square bracket glob..."
+	/usr/bin/fold -s <<< "Error: you did not use a square bracket glob..."
 	exit 4
 fi
 
 if [[ "${#ARGS[0]}" -gt 8 ]]
 then
-	fold -s <<< "Error: your argument is too long! It must be 8 characters or less."
+	/usr/bin/fold -s <<< "Error: your argument is too long! It must be 8 characters or less."
 	exit 5
 fi
 
@@ -37,10 +45,10 @@ ASTR=$@
 
 if [ "$EXPECTED" == "$ASTR" ]
 then
-	fold -s <<< "You got it! Here is your flag!"
-	cat /flag
+	/usr/bin/fold -s <<< "You got it! Here is your flag!"
+	/bin/cat /flag
 else
-	fold -s <<< "Your expansion did not expand to the requested files ($EXPECTED)."
-	fold -s <<< "Instead, it expanded to:"
+	/usr/bin/fold -s <<< "Your expansion did not expand to the requested files ($EXPECTED)."
+	/usr/bin/fold -s <<< "Instead, it expanded to:"
 	echo "$ASTR"
 fi

--- a/path/command-hijack/run
+++ b/path/command-hijack/run
@@ -1,12 +1,5 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 /bin/fold -s <<< "Trying to remove /flag..."
 

--- a/path/command-hijack/run
+++ b/path/command-hijack/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -s <<< "Trying to remove /flag..."
 

--- a/path/path-win-yours/run
+++ b/path/path-win-yours/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "Invoking 'win'...."
 win

--- a/path/path-win-yours/run
+++ b/path/path-win-yours/run
@@ -1,12 +1,4 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
 
 echo "Invoking 'win'...."
 win

--- a/path/path-win/run
+++ b/path/path-win/run
@@ -1,12 +1,6 @@
 #!/opt/pwn.college/bash
 # HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 echo "Invoking 'win'...."
 win

--- a/path/path-win/run
+++ b/path/path-win/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 echo "Invoking 'win'...."
 win

--- a/path/path/run
+++ b/path/path/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -s <<< "Trying to remove /flag..."
 rm -f /flag

--- a/path/path/run
+++ b/path/path/run
@@ -1,12 +1,6 @@
 #!/opt/pwn.college/bash
 # HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 /bin/fold -s <<< "Trying to remove /flag..."
 rm -f /flag

--- a/paths/absolute-cwd/run
+++ b/paths/absolute-cwd/run
@@ -1,12 +1,5 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 RANDOM=$(cksum /flag  | awk '{print $1}')
 CANDIDATES=(

--- a/paths/absolute-cwd/run
+++ b/paths/absolute-cwd/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 RANDOM=$(cksum /flag  | awk '{print $1}')
 CANDIDATES=(

--- a/paths/absolute/run
+++ b/paths/absolute/run
@@ -1,12 +1,4 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
 
 if [ "${0:0:1}" != "/" ]
 then

--- a/paths/absolute/run
+++ b/paths/absolute/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ "${0:0:1}" != "/" ]
 then

--- a/paths/home/run
+++ b/paths/home/run
@@ -1,31 +1,39 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ "$#" -eq 0 ]
 then
-	fold -s <<< "You must provide an argument to /challenge/run when you invoke it!"
+	/usr/bin/fold -s <<< "You must provide an argument to /challenge/run when you invoke it!"
 	exit 4
 fi
 
 read ARG < /tmp/.last_arg
 if [ "${#ARG}" -gt 3 ]
 then
-	fold -s <<< "The argument you provided must not have been longer than 3 characters (it's currently ${#ARG} characters long)!"
+	/usr/bin/fold -s <<< "The argument you provided must not have been longer than 3 characters (it's currently ${#ARG} characters long)!"
 	exit 1
 fi
 
 if [[ "$1" != /* ]]
 then
-	fold -s <<< "The argument you provided is not an absolute path!"
+	/usr/bin/fold -s <<< "The argument you provided is not an absolute path!"
 	exit 2
 fi
 
 if [[ "$1" != /home/* ]]
 then
-	fold -s <<< "The argument you provided is not under your home directory!"
+	/usr/bin/fold -s <<< "The argument you provided is not under your home directory!"
 	exit 3
 fi
 
 echo "Writing the file to $1!"
-cat /flag > "$1"
+/bin/cat /flag > "$1"
 echo "... and reading it back to you:"
-cat "$1"
+/bin/cat "$1"

--- a/paths/home/run
+++ b/paths/home/run
@@ -1,12 +1,5 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 if [ "$#" -eq 0 ]
 then

--- a/paths/relative-dot-local/run
+++ b/paths/relative-dot-local/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 NEEDED="/challenge"
 

--- a/paths/relative-dot-local/run
+++ b/paths/relative-dot-local/run
@@ -1,12 +1,5 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 NEEDED="/challenge"
 

--- a/paths/relative-dot/run
+++ b/paths/relative-dot/run
@@ -1,12 +1,4 @@
 #!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
 
 NEEDED="/"
 

--- a/paths/relative-dot/run
+++ b/paths/relative-dot/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 NEEDED="/"
 

--- a/paths/relative-naked/run
+++ b/paths/relative-naked/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 NEEDED="/"
 

--- a/paths/relative-naked/run
+++ b/paths/relative-naked/run
@@ -1,12 +1,4 @@
-#!/opt/pwn.college/bash
-# HARDENED-PATH
-set -euo pipefail
-IFS=' 	
-'
-unalias -a 2>/dev/null || true
-unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
-PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
-umask 022
+
 
 NEEDED="/"
 

--- a/permissions/chgrp-random/run
+++ b/permissions/chgrp-random/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "I have given you access to use the 'chgrp' command. Use it to enable the flag to be read, but first use 'id' to figure out the group name!"
+/usr/bin/fold -s <<< "I have given you access to use the 'chgrp' command. Use it to enable the flag to be read, but first use 'id' to figure out the group name!"

--- a/permissions/chgrp/run
+++ b/permissions/chgrp/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "I have given you access to use the 'chgrp' command. Use it to enable the flag to be read!"
+/usr/bin/fold -s <<< "I have given you access to use the 'chgrp' command. Use it to enable the flag to be read!"

--- a/permissions/chmod-absolute/run
+++ b/permissions/chmod-absolute/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/python
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 import pickle
 import random

--- a/permissions/chmod-flag/run
+++ b/permissions/chmod-flag/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "I have given you access to use the 'chmod' command. Use it to enable the flag to be read!"
+/usr/bin/fold -s <<< "I have given you access to use the 'chmod' command. Use it to enable the flag to be read!"

--- a/permissions/chmod/run
+++ b/permissions/chmod/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/python
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 import pickle
 import random

--- a/permissions/chown/run
+++ b/permissions/chown/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "I have given you access to use the 'chown' command. Use it to enable the flag to be read!"
+/usr/bin/fold -s <<< "I have given you access to use the 'chown' command. Use it to enable the flag to be read!"

--- a/permissions/execute/run
+++ b/permissions/execute/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /challenge/.solver

--- a/permissions/setuid/run
+++ b/permissions/setuid/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /challenge/DESCRIPTION.md
+/bin/cat /challenge/DESCRIPTION.md

--- a/piping/append/run
+++ b/piping/append/run
@@ -1,14 +1,22 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 exec 5>/dev/tty
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 if ! $DIR/chio.py --check_stdout_path /home/hacker/the-flag --chio_info_fd 5 --chio_warn_fd 5 --chio_hint_fd 5 --chio_test_fd 5 --chio_pass_fd 5 --chio_fail_fd 5 --chio_hype_fd 5
 then
-	#fold -s > /dev/tty <<< "You aren't redirecting stdout to /home/hacker/the-flag! Rerun me with the output redirected (in append mode!)."
+	#/usr/bin/fold -s > /dev/tty <<< "You aren't redirecting stdout to /home/hacker/the-flag! Rerun me with the output redirected (in append mode!)."
 	exit 1
 fi
 
-fold -s > /dev/tty <<< "I will write the flag in two parts to the file /home/hacker/the-flag! I'll do the first write directly to the file, and the second write, I'll do to stdout (if it's pointing at the file). If you redirect the output in append mode, the second write will append to (rather than overwrite) the first write, and you'll get the whole flag!"
+/usr/bin/fold -s > /dev/tty <<< "I will write the flag in two parts to the file /home/hacker/the-flag! I'll do the first write directly to the file, and the second write, I'll do to stdout (if it's pointing at the file). If you redirect the output in append mode, the second write will append to (rather than overwrite) the first write, and you'll get the whole flag!"
 
 (
 	echo " | "
@@ -22,4 +30,4 @@ echo "                              ^"
 echo "     that is the second half /|\\"
 echo "                              |"
 echo
-fold -s <<< "If you only see the second half above, you redirected in *truncate* mode (>) rather than *append* mode (>>), and so the write of the second half to stdout overwrote the initial write of the first half directly to the file. Try append mode!"
+/usr/bin/fold -s <<< "If you only see the second half above, you redirected in *truncate* mode (>) rather than *append* mode (>>), and so the write of the second half to stdout overwrote the initial write of the first half directly to the file. Try append mode!"

--- a/piping/echo/run
+++ b/piping/echo/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s < /challenge/DESCRIPTION.md
+/usr/bin/fold -s < /challenge/DESCRIPTION.md

--- a/piping/fifo/run
+++ b/piping/fifo/run
@@ -1,16 +1,24 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ ! -p /dev/stdout ]
 then
-	fold -s <<< "The stdout of /challenge/run does not seem to point to a FIFO!" >&2
+	/usr/bin/fold -s <<< "The stdout of /challenge/run does not seem to point to a FIFO!" >&2
 	exit 1
 fi
 
 if [ ! -f /tmp/.redirected ]
 then
-	fold -s <<< "You did not redirect /challenge/run's stdout to /tmp/flag_fifo!" >&2
+	/usr/bin/fold -s <<< "You did not redirect /challenge/run's stdout to /tmp/flag_fifo!" >&2
 	exit 2
 fi
 
-fold -s <<< "You've correctly redirected /challenge/run's stdout to a FIFO at /tmp/flag_fifo! Here is your flag:"
-cat /flag
+/usr/bin/fold -s <<< "You've correctly redirected /challenge/run's stdout to a FIFO at /tmp/flag_fifo! Here is your flag:"
+/bin/cat /flag

--- a/piping/grep-invert/run
+++ b/piping/grep-invert/run
@@ -1,6 +1,14 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-FLAG=$(cat /flag)
+FLAG=$(/bin/cat /flag)
 FLAG_CONTENT=$(sed 's/pwn\.college{\(.*\)}/\1/' <<< "$FLAG")
 
 # Generate 1000+ lines with decoys and the real flag

--- a/piping/pipe-grep/run
+++ b/piping/pipe-grep/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 $DIR/chio.py --check_stdout_pipe grep --reward /challenge/.data.txt --chio_flag_fd 1

--- a/piping/redir-then-grep/run
+++ b/piping/redir-then-grep/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 $DIR/chio.py --check_stdout_path /tmp/data.txt --reward /challenge/.data.txt --chio_flag_fd 1

--- a/piping/stderr-grep/run
+++ b/piping/stderr-grep/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 exec 5> /dev/tty

--- a/piping/stderr-myflag/run
+++ b/piping/stderr-myflag/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 exec $DIR/chio.py --reward /flag --check_stdout_path myflag --check_stderr_path instructions --chio_hint_fd -1 --chio_flag_fd 1

--- a/piping/stdin/run
+++ b/piping/stdin/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 
 STDIN_DIRNAME=$(dirname $(readlink /proc/self/fd/0))

--- a/piping/stdout-myflag/run
+++ b/piping/stdout-myflag/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 exec $DIR/chio.py --reward /flag --check_stdout_path myflag --chio_hint_fd -1 --chio_flag_fd 1

--- a/processes/background/run
+++ b/processes/background/run
@@ -1,9 +1,17 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 function resumed {
-	if [[ $(ps -o stat= -p $$) == *+* ]]
+	if [[ $(/bin/ps -o stat= -p $$) == *+* ]]
 	then
-		fold -s <<< "You resumed me into the foreground! Please resume me into the background (or press Enter, and I'll exit)."
+		/usr/bin/fold -s <<< "You resumed me into the foreground! Please resume me into the background (or press Enter, and I'll exit)."
 		read A
 		exit
 	fi
@@ -11,33 +19,33 @@ function resumed {
 	echo
 	echo
 	echo
-	fold -s <<< "Yay, I'm now running the background! Because of that, this text will probably overlap weirdly with the shell prompt. Don't panic; just hit Enter a few times to scroll this text out."
+	/usr/bin/fold -s <<< "Yay, I'm now running the background! Because of that, this text will probably overlap weirdly with the shell prompt. Don't panic; just hit Enter a few times to scroll this text out."
 	sleep 6h
 }
 trap resumed SIGCONT
 
 [[ "$BASH_EXECUTION_STRING" == .* ]] && exec -a bash /bin/bash $BASH_SOURCE
 
-fold -s <<< "I'll only give you the flag if there's already another copy of me running *and not suspended* in this terminal... Let's check!"
+/usr/bin/fold -s <<< "I'll only give you the flag if there's already another copy of me running *and not suspended* in this terminal... Let's check!"
 
 echo
-ps -o user=UID,pid,stat,cmd
+/bin/ps -o user=UID,pid,stat,cmd
 echo
 
-if ! ps -f | grep -v "$$" | grep -q "[r]un"
+if ! /bin/ps -f | grep -v "$$" | grep -q "[r]un"
 then
 	echo "I don't see a second me!"
 	echo
-	fold -s <<< "To pass this level, you need to suspend me, resume the suspended process in the background, and then launch a new version of me! You can background me with Ctrl-Z (and resume me in the background with 'bg') or, if you're not ready to do that for whatever reason, just hit Enter and I'll exit!"
+	/usr/bin/fold -s <<< "To pass this level, you need to suspend me, resume the suspended process in the background, and then launch a new version of me! You can background me with Ctrl-Z (and resume me in the background with 'bg') or, if you're not ready to do that for whatever reason, just hit Enter and I'll exit!"
 	read A
 	exit
 fi
 
-if ps -o user=UID,pid,stat,cmd | grep -v "$$" | grep "[r]un" | grep -q "[[:space:]]T[[:space:]]"
+if /bin/ps -o user=UID,pid,stat,cmd | grep -v "$$" | grep "[r]un" | grep -q "[[:space:]]T[[:space:]]"
 then
-	fold -s <<< "I found a second version of me, but it's suspended! Please resume it in the background with the 'bg' command, then run me again."
+	/usr/bin/fold -s <<< "I found a second version of me, but it's suspended! Please resume it in the background with the 'bg' command, then run me again."
 	exit
 fi
 
-fold -s <<< "Yay, I found another version of me running in the background! Here is the flag:"
-cat /flag
+/usr/bin/fold -s <<< "Yay, I found another version of me running in the background! Here is the flag:"
+/bin/cat /flag

--- a/processes/foreground/run
+++ b/processes/foreground/run
@@ -1,9 +1,17 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 function resumed {
-	if [[ $(ps -o stat= -p $$) == *+* ]]
+	if [[ $(/bin/ps -o stat= -p $$) == *+* ]]
 	then
-		fold -s <<< "You resumed me into the foreground from suspension! Please resume me into the background, and *then* swap me into the foreground directly from there (or press Enter, and I'll exit)."
+		/usr/bin/fold -s <<< "You resumed me into the foreground from suspension! Please resume me into the background, and *then* swap me into the foreground directly from there (or press Enter, and I'll exit)."
 		read A
 		exit
 	fi
@@ -11,18 +19,18 @@ function resumed {
 	echo
 	echo
 	echo
-	fold -s <<< "Yay, I'm now running the background! Because of that, this text will probably overlap weirdly with the shell prompt. Don't panic; just hit Enter a few times to scroll this text out. After that, resume me into the foreground with 'fg'; I'll wait."
+	/usr/bin/fold -s <<< "Yay, I'm now running the background! Because of that, this text will probably overlap weirdly with the shell prompt. Don't panic; just hit Enter a few times to scroll this text out. After that, resume me into the foreground with 'fg'; I'll wait."
 
-	until [[ $(ps -o stat= -p $$) == *+* ]]; do sleep 0.1; done
+	until [[ $(/bin/ps -o stat= -p $$) == *+* ]]; do sleep 0.1; done
 
-	fold -s <<< "YES! Great job! I'm now running in the foreground. Hit Enter for your flag!"
+	/usr/bin/fold -s <<< "YES! Great job! I'm now running in the foreground. Hit Enter for your flag!"
 	read A
-	cat /flag
+	/bin/cat /flag
 	exit
 }
 trap resumed SIGCONT
 
 [[ "$BASH_EXECUTION_STRING" == .* ]] && exec -a bash /bin/bash $BASH_SOURCE
 
-fold -s <<< "To pass this level, you need to suspend me, resume the suspended process in the background, and *then* foreground it without re-suspending it! You can background me with Ctrl-Z (and resume me in the background with 'bg') or, if you're not ready to do that for whatever reason, just hit Enter and I'll exit!"
+/usr/bin/fold -s <<< "To pass this level, you need to suspend me, resume the suspended process in the background, and *then* foreground it without re-suspending it! You can background me with Ctrl-Z (and resume me in the background with 'bg') or, if you're not ready to do that for whatever reason, just hit Enter and I'll exit!"
 read A

--- a/processes/int/run
+++ b/processes/int/run
@@ -1,11 +1,19 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "I could give you the flag... but I won't, until this process exits. Remember, you can force me to exit with Ctrl-C. Try it now!"
+/usr/bin/fold -s <<< "I could give you the flag... but I won't, until this process exits. Remember, you can force me to exit with Ctrl-C. Try it now!"
 
 function flag {
 	echo
-	fold -s <<< "Good job! You have used Ctrl-C to interrupt this process! Here is your flag:"
-	cat /flag
+	/usr/bin/fold -s <<< "Good job! You have used Ctrl-C to interrupt this process! Here is your flag:"
+	/bin/cat /flag
 }
 
 trap flag SIGINT

--- a/processes/kill-decoy/run
+++ b/processes/kill-decoy/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-fold -s <<< "Sending the flag to /tmp/flag_fifo!"
-cat /flag > /tmp/flag_fifo
+/usr/bin/fold -s <<< "Sending the flag to /tmp/flag_fifo!"
+/bin/cat /flag > /tmp/flag_fifo

--- a/processes/kill/run
+++ b/processes/kill/run
@@ -1,10 +1,18 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-if ps -ef | grep -q '[d]ont_run'
+if /bin/ps -ef | grep -q '[d]ont_run'
 then
-	fold -s <<< "Nope! /challenge/dont_run is still running! You gotta terminate it before I give you the flag!"
+	/usr/bin/fold -s <<< "Nope! /challenge/dont_run is still running! You gotta terminate it before I give you the flag!"
 	exit
 fi
 
-fold -s <<< "Great job! Here is your payment:"
-cat /flag
+/usr/bin/fold -s <<< "Great job! Here is your payment:"
+/bin/cat /flag

--- a/processes/ps/run
+++ b/processes/ps/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ -z "$DOIT" ]
 then
@@ -7,6 +15,6 @@ then
 fi
 
 echo "Yahaha, you found me! Here is your flag:"
-cat /flag
+/bin/cat /flag
 echo "Now I will sleep for a while (so that you could find me with 'ps')."
 sleep 6h

--- a/processes/resume/run
+++ b/processes/resume/run
@@ -1,13 +1,21 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 function win {
-	fold -s <<< "I'm back! Here's your flag:"
-	cat /flag
-	fold -s <<< "Don't forget to press Enter to quit me!"
+	/usr/bin/fold -s <<< "I'm back! Here's your flag:"
+	/bin/cat /flag
+	/usr/bin/fold -s <<< "Don't forget to press Enter to quit me!"
 }
 
 trap win SIGCONT
 
-fold -s <<< "Let's practice resuming processes! Suspend me with Ctrl-Z, then resume me with the 'fg' command! Or just press Enter to quit me!"
+/usr/bin/fold -s <<< "Let's practice resuming processes! Suspend me with Ctrl-Z, then resume me with the 'fg' command! Or just press Enter to quit me!"
 read A
 echo "Goodbye!"

--- a/processes/start-backgrounded/run
+++ b/processes/start-backgrounded/run
@@ -1,15 +1,23 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-if [[ $(ps -o stat= -p $$) == *+* ]]
+if [[ $(/bin/ps -o stat= -p $$) == *+* ]]
 then
-	fold -s <<< "You've started me in the foreground! You must start me in the background (by appending '&' to the command) to get the flag!"
+	/usr/bin/fold -s <<< "You've started me in the foreground! You must start me in the background (by appending '&' to the command) to get the flag!"
 	exit
 fi
 
 echo
 echo
 echo
-fold -s <<< "Yay, you started me in the background! Because of that, this text will probably overlap weirdly with the shell prompt, but you're used to that by now..."
+/usr/bin/fold -s <<< "Yay, you started me in the background! Because of that, this text will probably overlap weirdly with the shell prompt, but you're used to that by now..."
 echo
-fold -s <<< "Anyways! Here is your flag!"
-cat /flag
+/usr/bin/fold -s <<< "Anyways! Here is your flag!"
+/bin/cat /flag

--- a/processes/suspend/run
+++ b/processes/suspend/run
@@ -1,21 +1,29 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 [[ "$BASH_EXECUTION_STRING" == .* ]] && exec -a bash /bin/bash $BASH_SOURCE
 
-fold -s <<< "I'll only give you the flag if there's already another copy of me running in this terminal... Let's check!"
+/usr/bin/fold -s <<< "I'll only give you the flag if there's already another copy of me running in this terminal... Let's check!"
 
 echo
-ps -f
+/bin/ps -f
 echo
 
-if ps -f | grep -v "$$" | grep -q "[r]un"
+if /bin/ps -f | grep -v "$$" | grep -q "[r]un"
 then
-	fold -s <<< "Yay, I found another version of me! Here is the flag:"
-	cat /flag
+	/usr/bin/fold -s <<< "Yay, I found another version of me! Here is the flag:"
+	/bin/cat /flag
 	exit
 fi
 
 echo "I don't see a second me!"
 echo
-fold -s <<< "To pass this level, you need to suspend me and launch me again! You can background me with Ctrl-Z or, if you're not ready to do that for whatever reason, just hit Enter and I'll exit!"
+/usr/bin/fold -s <<< "To pass this level, you need to suspend me and launch me again! You can background me with Ctrl-Z or, if you're not ready to do that for whatever reason, just hit Enter and I'll exit!"
 read A

--- a/terminal-multiplexing/detach-attach-tmux/run
+++ b/terminal-multiplexing/detach-attach-tmux/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 TMUX_SESSION=$(su -c 'tmux ls' hacker 2>/dev/null | head -1 | cut -d: -f1)
 

--- a/terminal-multiplexing/detach-attach/run
+++ b/terminal-multiplexing/detach-attach/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 SCREEN_SESSION=$(su -c 'screen -ls' hacker | grep -E "Detached|Attached" | head -1 | awk '{print $1}')
 

--- a/users/su-crack/run
+++ b/users/su-crack/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 USER=$(whoami)
 
@@ -7,5 +15,5 @@ then
 	echo "Congratulations, you have become Zardus! Here is your flag:"
 	/challenge/.catflag
 else
-	fold -s <<< "You are the $USER user... You MUST become the zardus user before executing this command."
+	/usr/bin/fold -s <<< "You are the $USER user... You MUST become the zardus user before executing this command."
 fi

--- a/users/su-other/run
+++ b/users/su-other/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 USER=$(whoami)
 
@@ -7,5 +15,5 @@ then
 	echo "Congratulations, you have become Zardus! Here is your flag:"
 	/challenge/.catflag
 else
-	fold -s <<< "You are the $USER user... You MUST become the zardus user before executing this command."
+	/usr/bin/fold -s <<< "You are the $USER user... You MUST become the zardus user before executing this command."
 fi

--- a/users/su/run
+++ b/users/su/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /challenge/DESCRIPTION.md
+/bin/cat /challenge/DESCRIPTION.md

--- a/users/sudo/run
+++ b/users/sudo/run
@@ -1,3 +1,11 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
-cat /challenge/DESCRIPTION.md
+/bin/cat /challenge/DESCRIPTION.md

--- a/variables/command-substitution/run
+++ b/variables/command-substitution/run
@@ -1,12 +1,20 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ -t 1 ] || [ ! -f /tmp/subshell ]
 then
-	fold -s >&2 <<< "You are not running me via Command Substitution! Please make sure to run me with command substitution."
+	/usr/bin/fold -s >&2 <<< "You are not running me via Command Substitution! Please make sure to run me with command substitution."
 	exit 1
 elif [ ! -f /tmp/dstvar ]
 then
-	fold -s >&2 <<< 'You do not appear to be reading into a variable... Make sure to read me into a variable, e.g.:'
+	/usr/bin/fold -s >&2 <<< 'You do not appear to be reading into a variable... Make sure to read me into a variable, e.g.:'
 	echo '    VAR_NAME=$(/challenge/run)' >&2
 	exit 2
 fi
@@ -15,10 +23,10 @@ fi
 
 if [ "$DSTVAR" != "PWN" ]
 then
-	fold -s >&2 <<< "You are reading into the $DSTVAR variable, but you should read into the PWN variable. I am redacting the flag!"
+	/usr/bin/fold -s >&2 <<< "You are reading into the $DSTVAR variable, but you should read into the PWN variable. I am redacting the flag!"
 	echo "pwn.college{REDACTED}"
 	exit 3
 fi
 
-fold -s >&2 <<< "Congratulations! You have read the flag into the PWN variable. Now print it out and submit it!"
-cat /flag
+/usr/bin/fold -s >&2 <<< "Congratulations! You have read the flag into the PWN variable. Now print it out and submit it!"
+/bin/cat /flag

--- a/variables/echo/run
+++ b/variables/echo/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -w $(/bin/tput cols) -s <<END
 You cannot solve this challenge using /challenge/run.

--- a/variables/env/run
+++ b/variables/env/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -w $(/bin/tput cols) -s <<END
 You cannot solve this challenge using /challenge/run.

--- a/variables/export/run
+++ b/variables/export/run
@@ -1,4 +1,12 @@
 #!/opt/pwn.college/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 if [ -n "$COLLEGE" ]
 then
@@ -35,4 +43,4 @@ fi
 
 echo "CORRECT!"
 /bin/fold -s <<< "You have exported PWN=COLLEGE and set, but not exported, COLLEGE=PWN. Great job! Here is your flag:"
-cat /flag
+/bin/cat /flag

--- a/variables/read/run
+++ b/variables/read/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -w $(/bin/tput cols) -s <<END
 You cannot solve this challenge using /challenge/run.

--- a/variables/readfile/run
+++ b/variables/readfile/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -w $(/bin/tput cols) -s <<END
 You cannot solve this challenge using /challenge/run.

--- a/variables/setvar-multi/run
+++ b/variables/setvar-multi/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -w $(/bin/tput cols) -s <<END
 You cannot solve this challenge using /challenge/run.

--- a/variables/setvar/run
+++ b/variables/setvar/run
@@ -1,4 +1,12 @@
 #!/bin/bash
+# HARDENED-PATH
+set -euo pipefail
+IFS=' 	
+'
+unalias -a 2>/dev/null || true
+unset BASH_ENV ENV CDPATH SHELLOPTS EDITOR VISUAL PAGER SYSTEMD_PAGER LESSOPEN GIT_EDITOR GIT_PAGER LD_PRELOAD LD_LIBRARY_PATH
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"; export PATH
+umask 022
 
 /bin/fold -w $(/bin/tput cols) -s <<END
 You cannot solve this challenge using /challenge/run.


### PR DESCRIPTION
Several Linux Luminarium challenges can be completed without performing the intended task by placing attacker-controlled binaries earlier on PATH. The root-owned checker (e.g., /challenge/run) executes helper programs by bare name (ps, fold, cat, etc.). Because the checker runs with elevated privileges (setuid interpreter / root), those helpers are resolved through PATH, allowing a student to execute arbitrary code as the checker and directly read /flag. This bypasses the intended learning objectives and lets flags be obtained immediately.

