### PR TITLE
Added a hint to challenge "Mixing globs"

### DIFF
--- a/globbing/mixing/DESCRIPTION.md
+++ b/globbing/mixing/DESCRIPTION.md
@@ -2,4 +2,7 @@ Now, let's put the previous levels together!
 We put a few happy, but diversely-named files in `/challenge/files`.
 Go `cd` there and, using the globbing you've learned, write a single, short (6 characters or less) glob that (when passed as an argument to `/challenge/run`) will match **only** the files "challenging", "educational", and "pwning"!
 
-HINT: Make sure to look at the files in `/challenge/files`. Do you see any patterns that could help you make your glob?
+----
+**HINT:**
+Make sure to look at the names of the files in `/challenge/files`.
+Do you see any patterns that could help you make your glob?


### PR DESCRIPTION
This challenge doesn't serve any purpose without the user actually going to /challenge/files to find the pattern that makes the glob work. This should be specified in the description of the challenge.