### PR TITLE
Update instruction for decoy characters in DESCRIPTION.md

### DIFF
--- a/data/tr-delete/DESCRIPTION.md
+++ b/data/tr-delete/DESCRIPTION.md
@@ -9,5 +9,5 @@ hacker@dojo:~$
 
 Pretty simple!
 Now you give it a try.
-In /challenge/run, I'll intersperse some decoy characters (specifically: `^` and `%`) among the flag characters.
+In the output of /challenge/run, I'll intersperse some decoy characters (specifically: `^` and `%`) among the flag characters.
 Use `tr -d` to remove them!


### PR DESCRIPTION
This pull request makes a minor clarification to the instructions in the `DESCRIPTION.md` file. It specifies that the decoy characters will be interspersed in `/challenge/run` rather than in general.