### PR TITLE
Fix race condition in fg-from-bg challenge SIGCONT handler

### DIFF
--- a/processes/foreground/run
+++ b/processes/foreground/run
@@ -1,6 +1,8 @@
 #!/opt/pwn.college/bash
 
 function resumed {
+    trap 'unset _IN_RESUMED_HANDLER' RETURN
+
     if [[ -n "$_IN_RESUMED_HANDLER" ]]; then
         return
     fi


### PR DESCRIPTION
This fixes a race condition in the `fg-from-bg` challenge where the intended manual solution can fail nondeterministically.

The issue occurs because the SIGCONT handler may be invoked multiple times during a fast `bg → fg`
transition. If a second SIGCONT arrives while the handler is already running or while the process
is temporarily marked as foreground (+ in ps), the handler incorrectly takes the failure path
even when the user followed the correct steps.