### PR TITLE
[codex] tolerate missing /run in rm checkers

### DIFF
--- a/destruction/rm-rf-root-read/check
+++ b/destruction/rm-rf-root-read/check
@@ -10,7 +10,10 @@ while True:
         print("Looks like you haven't wiped the system! We'll check again in 5 seconds...")
     else:
         print("YES! You did it again! Go read the flag!")
-        os.chmod("/run", 0o000) # block off the nix stuff in PATH
+        try:
+            os.chmod("/run", 0o000) # block off the nix stuff in PATH
+        except FileNotFoundError:
+            pass
         with open("/flag", "w") as f:
             f.write(flag)
         os.chmod("/flag", 0o444)

--- a/destruction/rm-rf-root-search/check
+++ b/destruction/rm-rf-root-search/check
@@ -10,7 +10,10 @@ while True:
         print("Looks like you haven't wiped the system! We'll check again in 5 seconds...")
     else:
         print("YES! You did it again! Go read the flag!")
-        os.chmod("/run", 0o000) # block off the nix stuff in PATH
+        try:
+            os.chmod("/run", 0o000) # block off the nix stuff in PATH
+        except FileNotFoundError:
+            pass
         fn = "/"+os.urandom(4).hex()
         with open(fn, "w") as f:
             f.write(flag)


### PR DESCRIPTION
This hardens the `rm-rf-root-read` and `rm-rf-root-search` checkers when `/run` has already been removed by the wipe.

What changed:
- wrapped the `os.chmod("/run", 0o000)` call in both checkers with a narrow `FileNotFoundError` handler
- kept the existing inline comment explaining why `/run` is being blocked when it exists

Why this changed:
- both checkers intentionally block `/run` to cut off the nix-backed tool path after the wipe
- in practice, the checker can reach its success condition after `/run` is already gone
- when that happens, the unconditional `os.chmod("/run", 0o000)` raises `FileNotFoundError` and the checker dies before restoring the flag

Impact:
- preserves the intended behavior when `/run` exists
- avoids failing the challenge when `/run` is already absent, which is already an acceptable end state for the intended restriction

Root cause:
- the checker treated a missing `/run` as fatal even though missing `/run` already satisfies the purpose of blocking that path

Validation:
- `python3 -m py_compile destruction/rm-rf-root-read/check destruction/rm-rf-root-search/check`
